### PR TITLE
docs: document the update-feed branch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,12 @@ the `build` status check must pass. Every change ships through a PR against
   `body_path`).
 - **Do not create git tags manually.** `deploy-release.yml` creates the
   `v<version>` tag when it publishes.
+- The long-lived **`update-feed`** branch holds the AutoUpdater.NET feed: at each
+  release `deploy-release.yml` regenerates `update-installer.xml` from
+  `update-template.xml` on it, and the installed app polls that file to detect
+  new versions. It is a data-only branch — **do not delete it.** Deleting it
+  breaks the in-app update check and the release workflow (which commits to it).
+  If it is lost, recreate it from the last `Update for <version>` commit.
 - The full release-prep flow (decide SemVer, branch, build/test, bump version,
   write release notes, open the PR to `main`) is encoded in the
   **`prepare-release`** skill at `.claude/skills/prepare-release/`. Run it via


### PR DESCRIPTION
Documents the `update-feed` branch in CLAUDE.md: what it is (the AutoUpdater.NET feed, regenerated by `deploy-release.yml`), that the app polls it for updates, a **do-not-delete** warning, and how to restore it if lost.

This note was written on the `release/v2.1.4` branch but the squash-merge of #32 didn't carry it onto `main`, so it's ported here.

The `update-feed` branch itself is now also protected server-side (deletion blocked; direct pushes from the release workflow still allowed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
