### PR TITLE
build: keep typescript below 7 for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,11 @@ updates:
         patterns: ['svelte*', '@sveltejs/*']
       dev-dependencies:
         dependency-type: development
+    ignore:
+      # svelte-check 4.x declares a peer range of typescript ^5 || ^6, so a major
+      # bump makes npm ci fail to resolve before anything is even built.
+      - dependency-name: typescript
+        versions: ['>=7']
 
   - package-ecosystem: cargo
     directory: /src-tauri


### PR DESCRIPTION
The grouped dev-dependency bump in #39 raises typescript to `^7.0.2`, but `svelte-check@4.7.4` — the current release — still declares a peer range of `typescript: ^5.0.0 || ^6.0.0`. `npm ci` therefore fails with `ERESOLVE` in both jobs before anything is built; the `'vite' is not recognized` error that follows is only the missing `node_modules`.

This adds an ignore rule holding typescript below 7 until svelte-check widens its range.

#39 needs a `@dependabot recreate` comment afterwards to drop the typescript bump from the group.