### PR TITLE
fix: declare no data collection in the Firefox manifest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,14 @@ jobs:
             Write-Host "$browser $($manifest.version): $($hosts -join ', ')"
           }
 
+          # AMO rejects a submission that leaves this out, and it is written by the build
+          # rather than by hand — so nothing in the repository shows when it goes missing.
+          $gecko = (Get-Content 'dist/extension/firefox/manifest.json' -Raw | ConvertFrom-Json).browser_specific_settings.gecko
+          if (-not $gecko.id) { throw 'firefox manifest has no add-on id' }
+          $collects = $gecko.data_collection_permissions.required
+          if ($collects -ne 'none') { throw "firefox declares data collection: $($collects -join ', ')" }
+          Write-Host "firefox declares: id $($gecko.id), collects $collects"
+
       - name: Upload Test Coverage Report
         uses: actions/upload-artifact@v7
         with:

--- a/extension/store-listing.md
+++ b/extension/store-listing.md
@@ -142,22 +142,6 @@ rather than a mock-up. Five worth having, in order:
 Every screenshot needs the account content in it blurred or replaced with a throwaway account.
 A store screenshot is a permanent, indexed copy of whatever is on it.
 
------------------- | ----------------------- | --------------------------------------------- |
-| Store icon | 128×128 PNG | yes — `src-tauri/icons/128x128.png` may serve |
-| Screenshot | 1280×800 or 640×400 PNG | yes, at least 1, up to 5 |
-| Small promo tile | 440×280 PNG | only to be eligible for featuring |
-| Marquee promo tile | 1400×560 PNG | optional |
-
-Screenshots have to show the extension itself, not a mock-up, and the store rejects ones that
-are mostly text. What is worth showing, in order:
-
-1. The popup open over an X profile, mid-run, with the count climbing.
-2. The popup's action list, so the seven things it deletes are visible at a glance.
-3. A finished run with its result.
-
-Every screenshot needs the account content in it blurred or replaced with a throwaway account.
-A real timeline in a store screenshot is a permanent, indexed copy of it.
-
 ---
 
 ## Privacy tab
@@ -224,7 +208,12 @@ lie and the review into a takedown.
 
 ### Data usage
 
-Every category is answered **not collected**: personally identifiable information, health
+AMO reads this off the manifest rather than a form: `data_collection_permissions.required` is
+`["none"]`, which is the one value that cannot be listed beside another, and a submission
+without the key at all is now rejected outright. `build-extension.mjs` writes it into the
+Firefox manifest.
+
+Chrome asks the same question as a form. Every category is answered **not collected**: personally identifiable information, health
 information, financial information, authentication information, personal communications,
 location, web history, user activity, website content.
 

--- a/scripts/build-extension.mjs
+++ b/scripts/build-extension.mjs
@@ -89,10 +89,20 @@ async function buildAll() {
 
 	// Firefox implements MV3 background as an event page, not a service worker, and refuses an
 	// unsigned build without an explicit add-on id.
+	//
+	// `data_collection_permissions` is what AMO now rejects a submission for leaving out, and
+	// `none` is the whole of what this has to say: nothing is collected, which is also what the
+	// listing and PRIVACY.md say. It is the one value that may not appear beside another.
 	const firefox = {
 		...manifest,
 		background: { scripts: ['background.js'] },
-		browser_specific_settings: { gecko: { id: GECKO_ID, strict_min_version: GECKO_MIN } }
+		browser_specific_settings: {
+			gecko: {
+				id: GECKO_ID,
+				strict_min_version: GECKO_MIN,
+				data_collection_permissions: { required: ['none'] }
+			}
+		}
 	};
 	await writeFile(path.join(FIREFOX, 'manifest.json'), JSON.stringify(firefox, null, 2), 'utf8');
 


### PR DESCRIPTION
AMO rejects a submission without `data_collection_permissions`, and `none` is the whole of what this has to say — the same thing the listing and PRIVACY.md say. It is the one value that may not be listed beside another, which is what makes it worth asserting rather than assuming.

CI checks it, because the build writes the Firefox manifest and nothing in the repository would show the key going missing until an upload failed on it.

Also removes half a table left behind in `store-listing.md` when the graphics section was rewritten.