### PR TITLE
Firefox: declare no data collection, and raise the minimums that key needs

### DIFF
--- a/extension/store-listing.md
+++ b/extension/store-listing.md
@@ -247,7 +247,21 @@ AMO reuses the summary and description above. What it asks for separately:
   [extension/README.md](README.md).
 - **Add-on id** — `cleanmyposts@thorstenalpers.com`, already in the built manifest.
 - **Reviewer notes.** Say plainly that the add-on automates clicking on the user's own account
-  pages and why. A reviewer who works that out for themselves reads it as concealment.
+  pages and why. A reviewer who works that out for themselves reads it as concealment. Then the
+  one warning the validator raises, before they have to ask:
+
+```
+The "unsafe assignment to innerHTML" in assets/popup-*.js is Svelte 5's template
+instantiation, not a data path. Svelte sets innerHTML on a detached <template> element,
+from a string its compiler produced at build time, and routes it through a
+trustedTypes policy it registers as "svelte-trusted-html". No value from a page, a
+network response or a user reaches it — the popup renders no untrusted content at all.
+It cannot be avoided without changing UI frameworks; the same warning appears for every
+Svelte extension.
+```
+
+- **Minimum versions.** Firefox 140 and Firefox for Android 142, because that is where each
+  understood `data_collection_permissions`. `world: "MAIN"` already needed 128.
 
 ---
 

--- a/scripts/build-extension.mjs
+++ b/scripts/build-extension.mjs
@@ -23,7 +23,16 @@ const CHROME = path.join(OUT, 'chrome');
 const FIREFOX = path.join(OUT, 'firefox');
 
 const GECKO_ID = 'cleanmyposts@thorstenalpers.com';
-const GECKO_MIN = '128.0';
+/**
+ * 140 on desktop and 142 on Android, which is where each first understood
+ * `data_collection_permissions`.
+ *
+ * Not a free choice: AMO rejects a submission without that key and warns about one that claims
+ * to run on a Firefox predating it. `world: "MAIN"` — how the engine gets into the page at all
+ * — needs 128 anyway, so this only moves a floor that was already there.
+ */
+const GECKO_MIN = '140.0';
+const GECKO_ANDROID_MIN = '142.0';
 
 const alias = { $lib: path.resolve(ROOT, 'src/lib') };
 
@@ -101,7 +110,8 @@ async function buildAll() {
 				id: GECKO_ID,
 				strict_min_version: GECKO_MIN,
 				data_collection_permissions: { required: ['none'] }
-			}
+			},
+			gecko_android: { strict_min_version: GECKO_ANDROID_MIN }
 		}
 	};
 	await writeFile(path.join(FIREFOX, 'manifest.json'), JSON.stringify(firefox, null, 2), 'utf8');


### PR DESCRIPTION
AMO refused the 1.0.0 submission and then warned twice about the fix. Both are answered here.

## The rejection

`browser_specific_settings.gecko.data_collection_permissions` is now required for every new
Firefox add-on. For this one the answer is a single value:

```json
"data_collection_permissions": { "required": ["none"] }
```

`none` is the one value that may not be listed beside another — either nothing is collected or
it is enumerated. That matches what `PRIVACY.md` and the listing already say.

The build writes it into the Firefox manifest, so nothing in the repository would show the key
going missing until an upload failed on it again. **CI now asserts it**, along with the add-on
id.

## The two warnings

`data_collection_permissions` landed in Firefox 140, and in Firefox for Android 142. The
manifest invited 128, so the validator pointed out that the versions it welcomed would ignore
the key. Minimums raised to 140 and 142.

No real loss of reach: `world: "MAIN"`, which is how the engine reaches the page at all,
already needed 128. It also settles a caveat that has been in `extension/README.md` since the
world split — MAIN-world support is no longer an open question at these versions.

## The warning that stays

The validator flags an `innerHTML` assignment in the popup bundle. It is Svelte 5 instantiating
a template: a detached `<template>` element, a string its compiler produced at build time, and
a `trustedTypes` policy Svelte registers itself. Nothing from a page, a response or a user
reaches it, and no Svelte extension avoids it.

Rather than leave a reviewer to find that, `store-listing.md` now carries the explanation as
text to paste into the reviewer notes.

## Verified

- Built manifests read back: Firefox declares `none`, minimums 140/142, and Chrome has no
  `browser_specific_settings` at all
- The new CI assertion run locally against the built manifest
- `npm run lint` and `npm run check` clean

Also removes half a table left behind in `store-listing.md` when the graphics section was
rewritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)