### PR TITLE
AMO listing: privacy policy text, and the summary settled

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -22,10 +22,24 @@ The extension has no server component. There is nothing for data to be sent to.
 
 ## What is stored
 
-The browser extension stores one thing: the progress of a run in progress — which action is
-running and how many items it has removed so far — in `chrome.storage.session`. It exists so
-the count survives the browser stopping and restarting the extension's background worker
-mid-run. It is cleared when the browser closes, and it contains no content from any page.
+The browser extension stores two things, both in the browser's own extension storage and
+neither of them anywhere else.
+
+**Until the browser closes** (`storage.session`): the progress of a run — which action is
+running, how many items it has removed, the tab it is working in, and the recent lines of its
+log. This exists because Manifest V3 stops and restarts the extension's background worker
+while a run is going, and the count would be lost every time it did.
+
+It also holds your X handle for the length of a run. The handle is read off the page you are
+signed in to, and it is there because every X address the extension navigates to is built from
+it — `x.com/<handle>/likes` and so on. It is never sent anywhere, and it is gone when the
+browser closes.
+
+**Kept between sessions** (`storage.local`): your own preferences for the popup — which
+platforms to show, the three waits, the theme, the language, and whether the welcome note has
+been dismissed. Nothing here comes from a platform page.
+
+Neither store ever holds a post, a comment, a video title, or any other content from a page.
 
 The desktop app stores its own settings (theme, timeouts, log visibility) and its window
 position, in the user's own application data folder. It stores no posts, likes, comments or

--- a/extension/store-listing.md
+++ b/extension/store-listing.md
@@ -224,6 +224,58 @@ future versions as much as this one:
 - not being used or transferred for a purpose unrelated to the item's single purpose
 - not being used or transferred to determine creditworthiness or for lending
 
+### Privacy policy
+
+Chrome takes a URL. **AMO takes the text itself**, in a field on the submission form — this is
+what goes in it. `PRIVACY.md` in the repository root is the same statement covering both
+products, and is what the Chrome URL points at; the two have to be kept saying the same thing.
+
+```
+CleanMyPosts collects nothing, sends nothing anywhere, and has no server. There is no
+account to create and no analytics of any kind.
+
+WHAT IT READS
+
+The extension reads the page you have open on x.com or Google My Activity, for as long as
+it takes to find the next item and click it away. Nothing it reads is kept after the click
+— no post, comment, video title, or any other content from a page is ever written down or
+sent anywhere.
+
+WHAT IT STORES
+
+Two things, both in the browser's own extension storage:
+
+Until you close the browser: which action is running, how many items it has removed, the
+tab it is working in, and the recent lines of its log. Firefox stops and restarts an
+extension's background worker while it is running, and this is what survives that. It also
+holds your X handle for the length of a run, because every address the extension navigates
+to is built from it — x.com/<handle>/likes and so on. It is never sent anywhere.
+
+Kept between sessions: your own preferences for the popup — which platforms to show, the
+three waits, the theme, the language.
+
+WHAT IT SENDS
+
+Nothing. The extension has no server component and contacts no host of its own. It talks
+only to the sites you are already signed in to, by being on their pages.
+
+YOUR LOGIN
+
+Your session stays where it was: in the browser's cookie store, exactly as for any other
+site. The extension never reads, copies or transmits it.
+
+PERMISSIONS
+
+- storage: the two things above.
+- tabs: to find the tab to work in, drive it to the list being emptied, and reload it.
+  No browsing history is read and no other tab is looked at.
+- Access to x.com and myactivity.google.com: the pages the items are on. Nowhere else.
+
+No part of what the extension runs is fetched at runtime. Everything is in the package you
+installed, and all of it is public:
+https://github.com/thorstenalpers/CleanMyPosts
+```
+
 ### URLs
 
 | Field          | Value                                                               |

--- a/extension/store-listing.md
+++ b/extension/store-listing.md
@@ -18,10 +18,24 @@ CleanMyPosts
 
 ## Item summary
 
-`132 characters max — using 112`
+Chrome allows 132 characters, AMO 250. The same line fits both, and one line that is true in
+both places is worth more than two that have to be kept in step.
+
+`using 115 of Chrome's 132`
 
 ```
-Bulk-delete your posts, replies, reposts, likes and follows on X, and your comments and liked videos on YouTube.
+Bulk-delete your posts, replies, reposts, likes and followings on X, and your comments and liked videos on YouTube.
+```
+
+Naming both lists separately is the point of the length. "posts, replies, reposts, likes and
+followings on X or YouTube" is shorter and says the extension deletes reposts and followings on
+YouTube, which it cannot — there are none. A summary that promises a platform's features
+wrongly is the first thing a reviewer checks and the first thing a user is annoyed by.
+
+If it has to be shorter, this stays true at 97:
+
+```
+Bulk-delete what you posted, liked and followed on X, and your YouTube comments and liked videos.
 ```
 
 ## Detailed description
@@ -291,7 +305,12 @@ repository root is that policy.
 
 ## Firefox (addons.mozilla.org)
 
-AMO reuses the summary and description above. What it asks for separately:
+AMO reuses the summary and description above, unchanged — it accepts them as plain text, and
+the line breaks and bullets survive. It also allows a little HTML (`<b>`, `<a>`, `<ul>`,
+`<code>`), which is worth nothing here: a second copy of the description with tags in it would
+be a second thing to keep true, and the first one to go stale.
+
+What it asks for separately:
 
 - **Source code.** Because the submitted build is minified and bundled, AMO requires the source
   and exact build instructions. `npm ci && npm run build:extension` reproduces


### PR DESCRIPTION
Everything AMO's submission form asks for that was not written down yet.

## Privacy policy

AMO takes the policy as **text in a form field**, not as a link — Chrome takes the URL. The
text to paste is now in `store-listing.md`.

Writing it against the code found `PRIVACY.md` claiming the extension "stores one thing". It
stores three:

| | where | how long |
| --- | --- | --- |
| Run progress, tab, recent log lines | `storage.session` | until the browser closes |
| Popup preferences (platforms, waits, theme, language) | `storage.local` | kept |
| **Your X handle** | `storage.session` | length of a run |

The handle is the one worth saying out loud. It is read off the signed-in page because every X
address the extension navigates to is built from it — `x.com/<handle>/likes` and so on. It
never leaves the browser and goes when the browser closes, but it is held, and a privacy policy
that does not mention it is wrong.

This does not change the `none` in the manifest: Mozilla's data collection is about what leaves
the extension, and nothing does.

## Summary

One line for both stores. AMO allows 250 characters to Chrome's 132, so the same 115-character
line fits both — and one line that is true in two places beats two that have to be kept in
step.

A shorter alternative was on the table:

> Delete your posts, replies, reposts, likes and followings on X or / and Youtube.

It is 80 characters and it is wrong: it offers X's lists "on X or YouTube", which claims the
extension deletes reposts and followings on a platform that has neither. A summary that
promises a platform's features wrongly is the first thing a reviewer checks. A shorter line
that stays true is written down beside the chosen one, at 97 characters.

## Description

Unchanged, and used for both. AMO takes it as plain text; the line breaks and bullets survive.
It also allows some HTML, which buys nothing here — a tagged second copy would be a second
thing to keep true, and the first to go stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)