### PR TITLE
AMO listing: lead the description with what it does, file it under Privacy & Security

### DIFF
--- a/extension/store-listing.md
+++ b/extension/store-listing.md
@@ -119,8 +119,16 @@ and an optional AI assistant that writes new ones. Same engine, same repository.
 
 ## Category
 
-`Productivity` — the item does one job on the user's own account. Not "Social & Communication",
-which reads as a client for the platform rather than a tool that acts on it.
+`Privacy & Security`, in both stores — they name it near enough identically, so the add-on is
+not filed as two different things.
+
+What it does is remove the user's own trail. The alternative, `Social Networking` on Chrome and
+`Social & Communication` on AMO, is where tools that work _with_ a network live: feed filters,
+alternative clients, posting aids. This works against what a network has accumulated, and that
+is what somebody looking for it searches under.
+
+The argument against, for the record: it protects nothing and blocks nothing. Data minimisation
+is the part of that category it belongs to, alongside the trackers and the blockers.
 
 ## Language
 

--- a/extension/store-listing.md
+++ b/extension/store-listing.md
@@ -40,15 +40,21 @@ Bulk-delete what you posted, liked and followed on X, and your YouTube comments 
 
 ## Detailed description
 
-`16,000 characters max — using about 2,700`
+`16,000 characters max — using about 2,800`
+
+AMO warns that only the first 250 characters are read before anything else, and that is a
+better rule than a limit: the opening below says what the thing does and stops at 249, so
+nothing lands mid-sentence. What used to open it — why the platforms make this necessary — now
+comes second, where an explanation belongs.
 
 ```
+CleanMyPosts deletes your own posts, replies, reposts, likes and followings on X, and your comments and liked videos on YouTube — in bulk, in a tab you already have open, in the account you are signed in to. No API, no token, nothing to sign up for.
+
+WHY IT EXISTS
+
 Neither X nor YouTube will let you delete in bulk. Their interfaces remove one item at a time,
 each behind its own menu and its own confirmation — fine for a mistake, hopeless for ten years
 of posting.
-
-CleanMyPosts does it for you, in the tab in front of you, in the account you are already
-signed in to.
 
 WHAT IT DELETES
 


### PR DESCRIPTION
Two corrections the AMO submission form prompted. Both were written after #55 had already
merged and sat on that closed branch until now — they never reached `main`.

## Description

AMO reads the first 250 characters before anything else. The description opened on why the
platforms make bulk deletion necessary — an explanation, arriving before anyone had been told
what the extension is.

It now opens with the lists it deletes, where it does it and what it does not ask for, in 249
characters, so nothing is cut mid-sentence. The reason moved one heading down under
`WHY IT EXISTS`, which reads better anyway. Total is 2,735 characters, well inside Chrome's
16,000.

## Category

`Privacy & Security` in both stores, which name it near enough identically — so the add-on is
not filed as two different things.

It removes the user's own trail. `Social Networking` (Chrome) and `Social & Communication`
(AMO) are where tools that work *with* a network live: feed filters, alternative clients,
posting aids. This works against what a network has accumulated.

The argument against is written down with it: the extension protects nothing and blocks
nothing. Data minimisation is the part of that category it belongs to.

What was there before, `Productivity`, was neither — and is no longer a Chrome category at all.

## Nothing here reaches the package

Both files are documentation. The uploaded 1.0.0 needs no new version; these are listing
fields, which both stores let you edit independently of the submitted build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)