### PR TITLE
Fit SOURCE.md into AMO's reviewer-notes field

### DIFF
--- a/extension/SOURCE.md
+++ b/extension/SOURCE.md
@@ -1,109 +1,67 @@
 # Building this add-on from source
 
-This is what AMO's source code submission asks for. It is written for a reviewer who has this
-archive and nothing else.
+Written for a reviewer with this archive and nothing else, and short enough to paste whole into
+AMO's reviewer notes.
 
-The uploaded package is produced by Vite, which bundles and minifies, and by the Svelte
-compiler, which turns `.svelte` files into JavaScript. Nothing else is generated.
+The package is produced by Vite, which bundles and minifies, and by the Svelte compiler.
 
-## This archive holds two products
+## Two products in one archive
 
-CleanMyPosts is a Windows desktop app and a browser extension, in one repository, sharing the
-code that does the deleting. The archive is the whole repository, unstripped — nothing is
-filtered out of it, so what a reviewer builds is what the tag holds.
+CleanMyPosts is a Windows desktop app and a browser extension sharing the code that does the
+deleting. The archive is the whole repository, unstripped.
 
-**Only two directories matter for the add-on:**
-
-- `extension/` — the add-on itself
-- `src/lib/` — the engine it shares with the desktop app, plus the components the popup uses
-
-`src-tauri/` is the desktop app: Rust, a Tauri host, a Windows installer. **It is not built by
-anything below, it needs no toolchain you have to install, and no part of it ends up in the
-add-on.** `e2e/`, `release-notes/` and `assets/` are likewise not inputs to the add-on build.
-
-The archive is available two ways, and they hold the same commit:
-
-- The GitHub release for the tag, which carries it automatically:
-  `https://github.com/thorstenalpers/CleanMyPosts/archive/refs/tags/ext-<version>.zip`
-- Or `git archive --format=zip HEAD` from a checkout of that tag.
-
-GitHub's version puts everything one directory down, named after the repository and tag; run
-the commands below from inside it.
+For the add-on, only `extension/` (the add-on) and `src/lib/` (the shared delete engine, plus
+the components and locales the popup uses) matter. `src-tauri/` is the desktop app — Rust,
+built by none of the steps below, needing no toolchain you have to install, and reaching no
+part of the add-on. `e2e/`, `assets/` and `release-notes/` are not build inputs either.
 
 ## Build environment
 
-|                  |                                                                          |
-| ---------------- | ------------------------------------------------------------------------ |
-| Operating system | Any that Node runs on. Built and tested on Windows 11 and on Ubuntu (CI) |
-| Node.js          | 24.x — install from https://nodejs.org or `nvm install 24`               |
-| npm              | 11.x, which ships with Node 24                                           |
-| Anything else    | No. No Rust, no Python, no native toolchain.                             |
+- **OS:** any that Node runs on. Built on Windows 11 and on Ubuntu (CI).
+- **Node.js 24.x** — https://nodejs.org, or `nvm install 24`.
+- **npm 11.x**, which ships with Node 24.
+- Nothing else. No Rust, no Python, no native toolchain.
 
 ## Steps
 
-From the root of this archive:
+From the root of the archive (GitHub's zip puts it one directory down, named after the
+repository and tag — start inside that):
 
-```bash
-npm ci
-npm run build:extension
 ```
-
-The result is in `dist/extension/firefox/`, and is byte-for-byte what was uploaded apart from
-the source maps: `npm run pack:extension` is what produced the submitted zip, and it leaves
-`*.map` out.
-
-To produce the uploaded archive exactly:
-
-```bash
 npm ci
 npm run pack:extension
 ```
 
-That writes `dist/extension/cleanmyposts-firefox-<version>.zip`.
+`npm ci`, not `npm install`: it installs exactly what `package-lock.json` pins, so the build is
+the one that produced the upload.
 
-`npm ci` rather than `npm install`, deliberately: it installs exactly what `package-lock.json`
-pins, so the build is the same one that produced the upload.
+That writes `dist/extension/cleanmyposts-firefox-<version>.zip` — the uploaded package — and
+leaves it unpacked in `dist/extension/firefox/`.
 
 ## What the build does
 
-`scripts/build-extension.mjs`, in order:
+`scripts/build-extension.mjs`:
 
-1. Three separate Vite builds, each a single self-contained IIFE — `main-world.js`,
-   `content.js`, `background.js`. Separate because a content script cannot import anything, so
-   they cannot share a chunk.
+1. Three Vite builds, each a self-contained IIFE — `main-world.js`, `content.js`,
+   `background.js`. Separate because a content script cannot import, so they cannot share a
+   chunk.
 2. One Vite build for `popup.html` and its assets.
 3. Copies `extension/manifest.json` and the icons from `src-tauri/icons/`.
-4. Copies the whole result to `dist/extension/firefox/` and rewrites two manifest fields:
-   `background.service_worker` becomes `background.scripts` (Firefox implements MV3 background
-   as an event page), and `browser_specific_settings` is added with the add-on id, the minimum
-   versions, and `data_collection_permissions: { required: ["none"] }`.
+4. Copies the result to `dist/extension/firefox/` and rewrites two manifest fields:
+   `background.service_worker` becomes `background.scripts`, and `browser_specific_settings` is
+   added with the add-on id, the minimum versions, and
+   `data_collection_permissions: { required: ["none"] }`.
 
-Chrome's output and Firefox's differ in that one file and nothing else.
+Chrome's output differs from Firefox's in that one file and nothing else.
 
-## Where the code is
+## The one validator warning
 
-The add-on is thin. Almost all of it is the delete engine, which the desktop app in this
-repository runs unchanged.
-
-| Path                          | What                                                                  |
-| ----------------------------- | --------------------------------------------------------------------- |
-| `src/lib/engine/`             | Everything that touches a platform page: selectors, clicking, waiting |
-| `extension/src/main-world.ts` | Loads the engine into the page's own world                            |
-| `extension/src/content.ts`    | The isolated half; the only file with `chrome.*`                      |
-| `extension/src/background.ts` | Picks the page, drives the tab, relays progress                       |
-| `extension/src/popup/`        | The popup, in Svelte                                                  |
-| `extension/manifest.json`     | Chrome's manifest; the Firefox one is derived at build time           |
-| `scripts/build-extension.mjs` | The build                                                             |
-
-## Reproducing the review's own findings
-
-The validator flags one `innerHTML` assignment in `assets/popup-*.js`. It is Svelte 5
-instantiating a template — a detached `<template>` element, a string produced by its compiler
-at build time, and a `trustedTypes` policy Svelte registers as `svelte-trusted-html`. No value
-from a page, a network response or a user reaches it. It is in Svelte's runtime, not in any
-file in this archive, and it cannot be avoided without changing UI frameworks.
+The `innerHTML` assignment flagged in `assets/popup-*.js` is Svelte 5 instantiating a template:
+a detached `<template>` element, a string its compiler produced at build time, and a
+`trustedTypes` policy Svelte registers as `svelte-trusted-html`. No value from a page, a
+response or a user reaches it. It is in Svelte's runtime, not in any file here, and cannot be
+avoided without changing UI frameworks.
 
 ## The same code, in public
 
-This archive is a snapshot of https://github.com/thorstenalpers/CleanMyPosts at the tag for
-this version. Nothing is stripped from it.
+https://github.com/thorstenalpers/CleanMyPosts — this archive is the tag for this version.


### PR DESCRIPTION
AMO caps the reviewer notes at 3000 characters and rejected the paste at 3073.

`SOURCE.md` is meant to go into that field whole whenever the uploaded archive predates the
file — which is the case for `ext-v1.0.0` — so the length is a requirement, not a preference.

## The 73 characters were newlines

2988 as written, 3057 once Windows turns every newline into two. Nothing about the visible text
was near the limit; the line count was. It is now 2795, or 2862 CRLF-expanded — 138 to spare,
which survives another edit or two.

## What went

Only what a reviewer would not have read twice:

- A file listing that repeated what the section above it had already said in prose
- A second build command described alongside the first, differing only in keeping source maps

Everything AMO asks for by name is intact: operating system, Node and npm versions, the steps,
what the build does. So is the part that matters most in practice — that the archive holds two
products and `src-tauri/` is not one a reviewer has to build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)