### PR TITLE
v3.5.1: Reposts move to their own tab, header follows the page

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 3,
 	"name": "CleanMyPosts",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "Bulk-delete your posts, replies, reposts, likes and followings on X, and your comments and liked videos on YouTube.",
 	"icons": {
 		"32": "icons/32x32.png",

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -43,7 +43,7 @@ function targetUrl(platform: Platform, action: Action, userName: string): string
 			case 'deleteReplies':
 				return `https://x.com/${user}/with_replies`;
 			case 'deleteReposts':
-				return `https://x.com/${user}`;
+				return `https://x.com/${user}/reposts`;
 			case 'deleteLikes':
 				return `https://x.com/${user}/likes`;
 			case 'deleteFollowing':

--- a/release-notes/v3.5.1.md
+++ b/release-notes/v3.5.1.md
@@ -11,7 +11,7 @@
 
 **Elsewhere**
 
-- New: A reload button sits left of the address in the header while X or YouTube is up —
+- New: A reload button sits left of the platform name in the header while X or YouTube is up —
   the same reload a run already does when it finishes, now one click away.
 
 The extension carries the same fix on its own version line as v1.0.1.

--- a/release-notes/v3.5.1.md
+++ b/release-notes/v3.5.1.md
@@ -11,9 +11,10 @@
 
 **Elsewhere**
 
-- New: The header's address is a field while X or YouTube is up: type where to go, Enter
-  goes there. A bare domain gets its `https://`, a bare word becomes a Google search. A
-  reload button sits beside the assistant's, triggering the same reload a finished run
-  already does.
+- New: A reload button in the header, beside the assistant's, while X or YouTube is up —
+  triggering the same reload a finished run already does.
+- Fix: The address in the header now follows every navigation the page makes, wherever a
+  link leads. It used to freeze on the last platform page once the user left the
+  platform's own hosts.
 
 The extension carries the same fix on its own version line as v1.0.1.

--- a/release-notes/v3.5.1.md
+++ b/release-notes/v3.5.1.md
@@ -12,7 +12,8 @@
 **Elsewhere**
 
 - New: The header's address is a field while X or YouTube is up: type where to go, Enter
-  goes there — on the platform's own hosts and nowhere else. A reload button sits beside
-  the assistant's, triggering the same reload a finished run already does.
+  goes there. A bare domain gets its `https://`, a bare word becomes a Google search. A
+  reload button sits beside the assistant's, triggering the same reload a finished run
+  already does.
 
 The extension carries the same fix on its own version line as v1.0.1.

--- a/release-notes/v3.5.1.md
+++ b/release-notes/v3.5.1.md
@@ -1,0 +1,12 @@
+### What's Changed
+
+**Reposts moved, the app follows**
+
+- Fix: X moved reposts off the profile timeline into a Reposts tab of their own. Deleting
+  reposts still opened the profile, found nothing there that could be unretweeted, and
+  reported nothing to remove (#64). The app and the extension now open
+  `x.com/<user>/reposts`, which is where the reposts went.
+- Fix: The standalone script for reposts names the Reposts tab as the page to run it on.
+  Download it again if you kept a copy.
+
+The extension carries the same fix on its own version line as v1.0.1.

--- a/release-notes/v3.5.1.md
+++ b/release-notes/v3.5.1.md
@@ -9,4 +9,9 @@
 - Fix: The standalone script for reposts names the Reposts tab as the page to run it on.
   Download it again if you kept a copy.
 
+**Elsewhere**
+
+- New: A reload button sits left of the address in the header while X or YouTube is up —
+  the same reload a run already does when it finishes, now one click away.
+
 The extension carries the same fix on its own version line as v1.0.1.

--- a/release-notes/v3.5.1.md
+++ b/release-notes/v3.5.1.md
@@ -11,7 +11,8 @@
 
 **Elsewhere**
 
-- New: A reload button sits left of the platform name in the header while X or YouTube is up —
-  the same reload a run already does when it finishes, now one click away.
+- New: The header's address is a field while X or YouTube is up: type where to go, Enter
+  goes there — on the platform's own hosts and nowhere else. A reload button sits beside
+  the assistant's, triggering the same reload a finished run already does.
 
 The extension carries the same fix on its own version line as v1.0.1.

--- a/scripts/build-standalone.mjs
+++ b/scripts/build-standalone.mjs
@@ -41,7 +41,7 @@ const ACTIONS = [
 		file: 'cleanmyposts-x-delete-reposts',
 		from: 'x/reposts',
 		name: 'repostsAction',
-		page: 'your profile'
+		page: 'your profile’s Reposts tab'
 	},
 	{ file: 'cleanmyposts-x-delete-likes', from: 'x/likes', name: 'likesAction', page: 'your likes' },
 	{

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "cleanmyposts"
-version = "3.5.0"
+version = "3.5.1"
 dependencies = [
  "dirs",
  "keyring",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cleanmyposts"
-version = "3.5.0"
+version = "3.5.1"
 description = "Bulk-delete your posts, reposts, replies, likes and comments on X and YouTube"
 authors = ["thorstenalpers"]
 repository = "https://github.com/thorstenalpers/CleanMyPosts"

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -19,6 +19,7 @@ pub async fn dispatch(app: AppHandle, method: String, params: Value) -> Result<V
         "settings.reset" => settings::reset(&app),
 
         "site.navigate" => site::navigate(&app, &params),
+        "site.open" => site::open(&app, &params),
         "site.runAction" => site::run_action(app, &params).await,
         "site.runPlan" => site::run_plan(app, &params).await,
         "site.countMatches" => site::count_matches(app, &params).await,

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -19,7 +19,6 @@ pub async fn dispatch(app: AppHandle, method: String, params: Value) -> Result<V
         "settings.reset" => settings::reset(&app),
 
         "site.navigate" => site::navigate(&app, &params),
-        "site.open" => site::open(&app, &params),
         "site.runAction" => site::run_action(app, &params).await,
         "site.runPlan" => site::run_plan(app, &params).await,
         "site.countMatches" => site::count_matches(app, &params).await,

--- a/src-tauri/src/commands/site.rs
+++ b/src-tauri/src/commands/site.rs
@@ -23,7 +23,7 @@ fn target_url(platform: &str, action: &str, user_name: &str) -> Option<String> {
         ("x", "showReplies" | "deleteReplies") => {
             format!("https://x.com/{user}/with_replies")
         }
-        ("x", "showReposts" | "deleteReposts") => format!("https://x.com/{user}"),
+        ("x", "showReposts" | "deleteReposts") => format!("https://x.com/{user}/reposts"),
         ("x", "showLikes" | "deleteLikes") => format!("https://x.com/{user}/likes"),
         ("x", "showFollowing" | "deleteFollowing") => {
             format!("https://x.com/{user}/following")
@@ -663,7 +663,7 @@ mod tests {
         );
         assert_eq!(
             target_url("x", "deleteReposts", "someuser").unwrap(),
-            "https://x.com/someuser"
+            "https://x.com/someuser/reposts"
         );
         assert_eq!(
             target_url("x", "deleteLikes", "someuser").unwrap(),

--- a/src-tauri/src/commands/site.rs
+++ b/src-tauri/src/commands/site.rs
@@ -115,33 +115,6 @@ pub fn navigate(app: &AppHandle, params: &Value) -> Result<Value> {
     Ok(json!({ "ok": true }))
 }
 
-/// Opens an address the user typed into the header. Only the scheme is checked — a typed
-/// address must be a web page, never a script handed to `eval` by way of `javascript:`.
-pub fn open(app: &AppHandle, params: &Value) -> Result<Value> {
-    let platform = params
-        .get("platform")
-        .and_then(Value::as_str)
-        .ok_or(Error::MissingParam("platform"))?;
-    let url = params
-        .get("url")
-        .and_then(Value::as_str)
-        .ok_or(Error::MissingParam("url"))?;
-
-    let allowed =
-        tauri::Url::parse(url).is_ok_and(|parsed| matches!(parsed.scheme(), "https" | "http"));
-    if !allowed {
-        return Ok(json!({ "ok": false }));
-    }
-
-    let site = app
-        .get_webview(crate::site_webview_label(platform))
-        .ok_or_else(|| Error::Site("site webview is gone".into()))?;
-    site.eval(format!("window.location.assign({});", json!(url)))?;
-    // Like `navigate`, the address itself stays out of the log: it can carry the handle.
-    crate::bridge::log(app, "info", format!("{platform}: opening a typed address"));
-    Ok(json!({ "ok": true }))
-}
-
 /// Keeps the page shielded across the wait that follows a navigation.
 ///
 /// The run has already started as far as the user is concerned — the stop button is up and

--- a/src-tauri/src/commands/site.rs
+++ b/src-tauri/src/commands/site.rs
@@ -115,9 +115,8 @@ pub fn navigate(app: &AppHandle, params: &Value) -> Result<Value> {
     Ok(json!({ "ok": true }))
 }
 
-/// Opens an address the user typed into the header, on the platform's own hosts and nowhere
-/// else: the webview carries a signed-in session, and a typed address is the one navigation
-/// that does not come out of `target_url`.
+/// Opens an address the user typed into the header. Only the scheme is checked — a typed
+/// address must be a web page, never a script handed to `eval` by way of `javascript:`.
 pub fn open(app: &AppHandle, params: &Value) -> Result<Value> {
     let platform = params
         .get("platform")
@@ -128,12 +127,8 @@ pub fn open(app: &AppHandle, params: &Value) -> Result<Value> {
         .and_then(Value::as_str)
         .ok_or(Error::MissingParam("url"))?;
 
-    let allowed = tauri::Url::parse(url).is_ok_and(|parsed| {
-        parsed.scheme() == "https"
-            && parsed
-                .host_str()
-                .is_some_and(|host| host_allowed(platform, host))
-    });
+    let allowed =
+        tauri::Url::parse(url).is_ok_and(|parsed| matches!(parsed.scheme(), "https" | "http"));
     if !allowed {
         return Ok(json!({ "ok": false }));
     }
@@ -145,18 +140,6 @@ pub fn open(app: &AppHandle, params: &Value) -> Result<Value> {
     // Like `navigate`, the address itself stays out of the log: it can carry the handle.
     crate::bridge::log(app, "info", format!("{platform}: opening a typed address"));
     Ok(json!({ "ok": true }))
-}
-
-/// Whole hosts, never substrings: "x.com.example.net" ends in neither.
-fn host_allowed(platform: &str, host: &str) -> bool {
-    let hosts: &[&str] = match platform {
-        "x" => &["x.com"],
-        "youtube" => &["youtube.com", "myactivity.google.com"],
-        _ => return false,
-    };
-    hosts
-        .iter()
-        .any(|allowed| host == *allowed || host.ends_with(&format!(".{allowed}")))
 }
 
 /// Keeps the page shielded across the wait that follows a navigation.
@@ -717,18 +700,6 @@ mod tests {
             target_url("x", "showFollowing", "someuser").unwrap(),
             "https://x.com/someuser/following"
         );
-    }
-
-    #[test]
-    fn typed_addresses_stay_on_the_platform() {
-        assert!(host_allowed("x", "x.com"));
-        assert!(host_allowed("x", "mobile.x.com"));
-        assert!(!host_allowed("x", "x.com.example.net"));
-        assert!(!host_allowed("x", "youtube.com"));
-        assert!(host_allowed("youtube", "www.youtube.com"));
-        assert!(host_allowed("youtube", "myactivity.google.com"));
-        assert!(!host_allowed("youtube", "google.com"));
-        assert!(!host_allowed("other", "x.com"));
     }
 
     /// `show*` and `delete*` land on the same page; deleting happens where the items are

--- a/src-tauri/src/commands/site.rs
+++ b/src-tauri/src/commands/site.rs
@@ -115,6 +115,50 @@ pub fn navigate(app: &AppHandle, params: &Value) -> Result<Value> {
     Ok(json!({ "ok": true }))
 }
 
+/// Opens an address the user typed into the header, on the platform's own hosts and nowhere
+/// else: the webview carries a signed-in session, and a typed address is the one navigation
+/// that does not come out of `target_url`.
+pub fn open(app: &AppHandle, params: &Value) -> Result<Value> {
+    let platform = params
+        .get("platform")
+        .and_then(Value::as_str)
+        .ok_or(Error::MissingParam("platform"))?;
+    let url = params
+        .get("url")
+        .and_then(Value::as_str)
+        .ok_or(Error::MissingParam("url"))?;
+
+    let allowed = tauri::Url::parse(url).is_ok_and(|parsed| {
+        parsed.scheme() == "https"
+            && parsed
+                .host_str()
+                .is_some_and(|host| host_allowed(platform, host))
+    });
+    if !allowed {
+        return Ok(json!({ "ok": false }));
+    }
+
+    let site = app
+        .get_webview(crate::site_webview_label(platform))
+        .ok_or_else(|| Error::Site("site webview is gone".into()))?;
+    site.eval(format!("window.location.assign({});", json!(url)))?;
+    // Like `navigate`, the address itself stays out of the log: it can carry the handle.
+    crate::bridge::log(app, "info", format!("{platform}: opening a typed address"));
+    Ok(json!({ "ok": true }))
+}
+
+/// Whole hosts, never substrings: "x.com.example.net" ends in neither.
+fn host_allowed(platform: &str, host: &str) -> bool {
+    let hosts: &[&str] = match platform {
+        "x" => &["x.com"],
+        "youtube" => &["youtube.com", "myactivity.google.com"],
+        _ => return false,
+    };
+    hosts
+        .iter()
+        .any(|allowed| host == *allowed || host.ends_with(&format!(".{allowed}")))
+}
+
 /// Keeps the page shielded across the wait that follows a navigation.
 ///
 /// The run has already started as far as the user is concerned — the stop button is up and
@@ -673,6 +717,18 @@ mod tests {
             target_url("x", "showFollowing", "someuser").unwrap(),
             "https://x.com/someuser/following"
         );
+    }
+
+    #[test]
+    fn typed_addresses_stay_on_the_platform() {
+        assert!(host_allowed("x", "x.com"));
+        assert!(host_allowed("x", "mobile.x.com"));
+        assert!(!host_allowed("x", "x.com.example.net"));
+        assert!(!host_allowed("x", "youtube.com"));
+        assert!(host_allowed("youtube", "www.youtube.com"));
+        assert!(host_allowed("youtube", "myactivity.google.com"));
+        assert!(!host_allowed("youtube", "google.com"));
+        assert!(!host_allowed("other", "x.com"));
     }
 
     /// `show*` and `delete*` land on the same page; deleting happens where the items are

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -533,13 +533,31 @@ pub fn run() {
             // may land a beat early.
             let auto_consent = app.state::<AppState>().settings.get().auto_consent;
             let site_window = window.clone();
+            let nav_handle = app.handle().clone();
             let _ = window.run_on_main_thread(move || {
                 for (label, url) in SITE_WEBVIEWS {
+                    // The injected reporter goes quiet the moment the user leaves the
+                    // platform's hosts, and the header would keep showing the last address it
+                    // heard. This hook fires on every document navigation, whatever the host.
+                    let platform = if label == "site-youtube" {
+                        "youtube"
+                    } else {
+                        "x"
+                    };
+                    let handle = nav_handle.clone();
                     let built = site_window.add_child(
                         WebviewBuilder::new(
                             label,
                             WebviewUrl::External(url.parse().expect("static url")),
                         )
+                        .on_navigation(move |url| {
+                            crate::bridge::push_event(
+                                &handle,
+                                "siteUrl",
+                                serde_json::json!({ "platform": platform, "url": url.as_str() }),
+                            );
+                            true
+                        })
                         .initialization_script_for_all_frames(site_init_script(auto_consent)),
                         LogicalPosition::new(size.width, f64::from(DEFAULT_HEADER_HEIGHT)),
                         LogicalSize::new(

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "CleanMyPosts",
-	"version": "3.5.0",
+	"version": "3.5.1",
 	"identifier": "com.thorstenalpers.cleanmyposts",
 	"build": {
 		"frontendDist": "../build",

--- a/src/lib/bridge/contract.ts
+++ b/src/lib/bridge/contract.ts
@@ -326,7 +326,7 @@ export const BridgeMethods = {
 		params: z.object({ platform: PlatformSchema, action: SiteActionSchema }),
 		result: z.object({ ok: z.boolean() })
 	},
-	/** A typed address from the header. The host refuses anything off the platform's hosts. */
+	/** A typed address from the header. The host refuses anything that is not http(s). */
 	'site.open': {
 		params: z.object({ platform: PlatformSchema, url: z.string().url().max(500) }),
 		result: z.object({ ok: z.boolean() })

--- a/src/lib/bridge/contract.ts
+++ b/src/lib/bridge/contract.ts
@@ -472,6 +472,17 @@ export const SiteLoginPayloadSchema = z.object({
 });
 export type SiteLoginPayload = z.infer<typeof SiteLoginPayloadSchema>;
 
+/**
+ * Every document navigation of a platform's webview, reported by the host. The injected
+ * reporter only speaks on the platform's own hosts; this is what keeps the header's address
+ * honest when the user follows a link off them.
+ */
+export const SiteUrlPayloadSchema = z.object({
+	platform: PlatformSchema,
+	url: z.string()
+});
+export type SiteUrlPayload = z.infer<typeof SiteUrlPayloadSchema>;
+
 export const UpdateProgressPayloadSchema = z.object({
 	downloaded: z.number().int().nonnegative(),
 	/** Absent when the server sends no length; the bar runs indeterminate then. */
@@ -484,7 +495,8 @@ export const PushEventSchema = z.discriminatedUnion('event', [
 	z.object({ event: z.literal('progress'), payload: ProgressPayloadSchema }),
 	z.object({ event: z.literal('updateProgress'), payload: UpdateProgressPayloadSchema }),
 	z.object({ event: z.literal('settingsChanged'), payload: AppSettingsSchema }),
-	z.object({ event: z.literal('siteLogin'), payload: SiteLoginPayloadSchema })
+	z.object({ event: z.literal('siteLogin'), payload: SiteLoginPayloadSchema }),
+	z.object({ event: z.literal('siteUrl'), payload: SiteUrlPayloadSchema })
 ]);
 export type PushEvent = z.infer<typeof PushEventSchema>;
 

--- a/src/lib/bridge/contract.ts
+++ b/src/lib/bridge/contract.ts
@@ -326,11 +326,6 @@ export const BridgeMethods = {
 		params: z.object({ platform: PlatformSchema, action: SiteActionSchema }),
 		result: z.object({ ok: z.boolean() })
 	},
-	/** A typed address from the header. The host refuses anything that is not http(s). */
-	'site.open': {
-		params: z.object({ platform: PlatformSchema, url: z.string().url().max(500) }),
-		result: z.object({ ok: z.boolean() })
-	},
 	'site.runAction': {
 		params: z.object({
 			/** Minted by the caller so `progress` push events (which outlive the RPC round-trip) can be correlated back to this run. */

--- a/src/lib/bridge/contract.ts
+++ b/src/lib/bridge/contract.ts
@@ -326,6 +326,11 @@ export const BridgeMethods = {
 		params: z.object({ platform: PlatformSchema, action: SiteActionSchema }),
 		result: z.object({ ok: z.boolean() })
 	},
+	/** A typed address from the header. The host refuses anything off the platform's hosts. */
+	'site.open': {
+		params: z.object({ platform: PlatformSchema, url: z.string().url().max(500) }),
+		result: z.object({ ok: z.boolean() })
+	},
 	'site.runAction': {
 		params: z.object({
 			/** Minted by the caller so `progress` push events (which outlive the RPC round-trip) can be correlated back to this run. */

--- a/src/lib/bridge/mock.ts
+++ b/src/lib/bridge/mock.ts
@@ -113,6 +113,7 @@ export function defaultMockHandlers(): MockHandlers {
 		'settings.set': () => undefined,
 		'settings.reset': () => mockSettings(),
 		'site.navigate': () => ({ ok: true }),
+		'site.open': () => ({ ok: true }),
 		'site.runAction': () => ({ deletedCount: 0 }),
 		'site.cancelAction': () => undefined,
 		'site.hide': () => undefined,

--- a/src/lib/bridge/mock.ts
+++ b/src/lib/bridge/mock.ts
@@ -113,7 +113,6 @@ export function defaultMockHandlers(): MockHandlers {
 		'settings.set': () => undefined,
 		'settings.reset': () => mockSettings(),
 		'site.navigate': () => ({ ok: true }),
-		'site.open': () => ({ ok: true }),
 		'site.runAction': () => ({ deletedCount: 0 }),
 		'site.cancelAction': () => undefined,
 		'site.hide': () => undefined,

--- a/src/lib/components/page-header.svelte
+++ b/src/lib/components/page-header.svelte
@@ -31,6 +31,8 @@
 		onOpenActions?: () => void;
 		/** Given only while a platform is up: the app's own pages have nothing to reload. */
 		onReload?: () => void;
+		/** Makes the address editable; Enter hands the typed url over. Platforms only. */
+		onNavigate?: (url: string) => void;
 		/** The assistant lives in the app's own column, so its way in belongs in this bar. */
 		onToggleAssistant?: () => void;
 		assistantOpen?: boolean;
@@ -44,10 +46,25 @@
 		settingsStore,
 		onMenuOpenChange,
 		onReload,
+		onNavigate,
 		onOpenActions,
 		onToggleAssistant,
 		assistantOpen = false
 	}: Props = $props();
+
+	let address = $state('');
+	$effect(() => {
+		address = location;
+	});
+
+	function onAddressKeydown(event: KeyboardEvent): void {
+		if (event.key === 'Enter') {
+			const typed = address.trim();
+			if (typed) onNavigate?.(typed.includes('://') ? typed : `https://${typed}`);
+		} else if (event.key === 'Escape') {
+			address = location;
+		}
+	}
 </script>
 
 <header class="flex h-11 shrink-0 items-center gap-2 border-b bg-background px-3">
@@ -62,18 +79,6 @@
 		</button>
 	{/if}
 
-	{#if onReload}
-		<button
-			type="button"
-			aria-label={t('header.reload')}
-			title={t('header.reload')}
-			onclick={onReload}
-			class="flex size-7 shrink-0 cursor-pointer items-center justify-center rounded-md text-muted-foreground transition-colors duration-150 hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
-		>
-			<RefreshCwIcon class="size-4" />
-		</button>
-	{/if}
-
 	{#if icon}
 		{@const Icon = icon}
 		<Icon class="size-4 shrink-0 {iconOnly ? 'text-foreground' : 'text-muted-foreground'}" />
@@ -83,15 +88,37 @@
 		{title}
 	</span>
 
-	<span
-		title={location}
-		aria-label={t('header.url')}
-		class="min-w-0 flex-1 truncate rounded-md bg-muted/60 px-2 py-1 font-mono text-[11px] text-muted-foreground"
-	>
-		{location}
-	</span>
+	{#if onNavigate}
+		<input
+			type="text"
+			spellcheck="false"
+			aria-label={t('header.url')}
+			bind:value={address}
+			onkeydown={onAddressKeydown}
+			class="min-w-0 flex-1 truncate rounded-md bg-muted/60 px-2 py-1 font-mono text-[11px] text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+		/>
+	{:else}
+		<span
+			title={location}
+			aria-label={t('header.url')}
+			class="min-w-0 flex-1 truncate rounded-md bg-muted/60 px-2 py-1 font-mono text-[11px] text-muted-foreground"
+		>
+			{location}
+		</span>
+	{/if}
 
 	<div class="flex shrink-0 items-center gap-0.5">
+		{#if onReload}
+			<button
+				type="button"
+				aria-label={t('header.reload')}
+				title={t('header.reload')}
+				onclick={onReload}
+				class="flex size-7 shrink-0 cursor-pointer items-center justify-center rounded-md text-muted-foreground transition-colors duration-150 hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+			>
+				<RefreshCwIcon class="size-4" />
+			</button>
+		{/if}
 		{#if onToggleAssistant}
 			<button
 				type="button"

--- a/src/lib/components/page-header.svelte
+++ b/src/lib/components/page-header.svelte
@@ -52,10 +52,7 @@
 		assistantOpen = false
 	}: Props = $props();
 
-	let address = $state('');
-	$effect(() => {
-		address = location;
-	});
+	let address = $derived(location);
 
 	/** What a browser's address bar does: a domain gets its scheme, anything else a search. */
 	function toUrl(typed: string): string {

--- a/src/lib/components/page-header.svelte
+++ b/src/lib/components/page-header.svelte
@@ -4,6 +4,7 @@
 	import LanguageMenu from '$lib/components/language-menu.svelte';
 	import ModeToggle from '$lib/components/mode-toggle.svelte';
 	import PanelLeftIcon from '@lucide/svelte/icons/panel-left';
+	import RefreshCwIcon from '@lucide/svelte/icons/refresh-cw';
 	import SparklesIcon from '@lucide/svelte/icons/sparkles';
 	import { cn } from '$lib/utils';
 	import type { SettingsStore } from '$lib/stores/settings.svelte';
@@ -28,6 +29,8 @@
 		 * it, so this is the way back.
 		 */
 		onOpenActions?: () => void;
+		/** Given only while a platform is up: the app's own pages have nothing to reload. */
+		onReload?: () => void;
 		/** The assistant lives in the app's own column, so its way in belongs in this bar. */
 		onToggleAssistant?: () => void;
 		assistantOpen?: boolean;
@@ -40,6 +43,7 @@
 		iconOnly = false,
 		settingsStore,
 		onMenuOpenChange,
+		onReload,
 		onOpenActions,
 		onToggleAssistant,
 		assistantOpen = false
@@ -66,6 +70,18 @@
 	<span class={iconOnly ? 'sr-only' : 'shrink-0 text-[13px] font-semibold tracking-tight'}>
 		{title}
 	</span>
+
+	{#if onReload}
+		<button
+			type="button"
+			aria-label={t('header.reload')}
+			title={t('header.reload')}
+			onclick={onReload}
+			class="flex size-7 shrink-0 cursor-pointer items-center justify-center rounded-md text-muted-foreground transition-colors duration-150 hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+		>
+			<RefreshCwIcon class="size-4" />
+		</button>
+	{/if}
 
 	<span
 		title={location}

--- a/src/lib/components/page-header.svelte
+++ b/src/lib/components/page-header.svelte
@@ -31,8 +31,6 @@
 		onOpenActions?: () => void;
 		/** Given only while a platform is up: the app's own pages have nothing to reload. */
 		onReload?: () => void;
-		/** Makes the address editable; Enter hands the typed url over. Platforms only. */
-		onNavigate?: (url: string) => void;
 		/** The assistant lives in the app's own column, so its way in belongs in this bar. */
 		onToggleAssistant?: () => void;
 		assistantOpen?: boolean;
@@ -46,29 +44,10 @@
 		settingsStore,
 		onMenuOpenChange,
 		onReload,
-		onNavigate,
 		onOpenActions,
 		onToggleAssistant,
 		assistantOpen = false
 	}: Props = $props();
-
-	let address = $derived(location);
-
-	/** What a browser's address bar does: a domain gets its scheme, anything else a search. */
-	function toUrl(typed: string): string {
-		if (typed.includes('://')) return typed;
-		if (typed.includes('.') && !typed.includes(' ')) return `https://${typed}`;
-		return `https://www.google.com/search?q=${encodeURIComponent(typed)}`;
-	}
-
-	function onAddressKeydown(event: KeyboardEvent): void {
-		if (event.key === 'Enter') {
-			const typed = address.trim();
-			if (typed) onNavigate?.(toUrl(typed));
-		} else if (event.key === 'Escape') {
-			address = location;
-		}
-	}
 </script>
 
 <header class="flex h-11 shrink-0 items-center gap-2 border-b bg-background px-3">
@@ -92,24 +71,13 @@
 		{title}
 	</span>
 
-	{#if onNavigate}
-		<input
-			type="text"
-			spellcheck="false"
-			aria-label={t('header.url')}
-			bind:value={address}
-			onkeydown={onAddressKeydown}
-			class="min-w-0 flex-1 truncate rounded-md bg-muted/60 px-2 py-1 font-mono text-[11px] text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
-		/>
-	{:else}
-		<span
-			title={location}
-			aria-label={t('header.url')}
-			class="min-w-0 flex-1 truncate rounded-md bg-muted/60 px-2 py-1 font-mono text-[11px] text-muted-foreground"
-		>
-			{location}
-		</span>
-	{/if}
+	<span
+		title={location}
+		aria-label={t('header.url')}
+		class="min-w-0 flex-1 truncate rounded-md bg-muted/60 px-2 py-1 font-mono text-[11px] text-muted-foreground"
+	>
+		{location}
+	</span>
 
 	<div class="flex shrink-0 items-center gap-0.5">
 		{#if onReload}

--- a/src/lib/components/page-header.svelte
+++ b/src/lib/components/page-header.svelte
@@ -62,15 +62,6 @@
 		</button>
 	{/if}
 
-	{#if icon}
-		{@const Icon = icon}
-		<Icon class="size-4 shrink-0 {iconOnly ? 'text-foreground' : 'text-muted-foreground'}" />
-	{/if}
-	<!-- Still announced when it is not drawn: the mark carries the name for the eye only. -->
-	<span class={iconOnly ? 'sr-only' : 'shrink-0 text-[13px] font-semibold tracking-tight'}>
-		{title}
-	</span>
-
 	{#if onReload}
 		<button
 			type="button"
@@ -82,6 +73,15 @@
 			<RefreshCwIcon class="size-4" />
 		</button>
 	{/if}
+
+	{#if icon}
+		{@const Icon = icon}
+		<Icon class="size-4 shrink-0 {iconOnly ? 'text-foreground' : 'text-muted-foreground'}" />
+	{/if}
+	<!-- Still announced when it is not drawn: the mark carries the name for the eye only. -->
+	<span class={iconOnly ? 'sr-only' : 'shrink-0 text-[13px] font-semibold tracking-tight'}>
+		{title}
+	</span>
 
 	<span
 		title={location}

--- a/src/lib/components/page-header.svelte
+++ b/src/lib/components/page-header.svelte
@@ -57,10 +57,17 @@
 		address = location;
 	});
 
+	/** What a browser's address bar does: a domain gets its scheme, anything else a search. */
+	function toUrl(typed: string): string {
+		if (typed.includes('://')) return typed;
+		if (typed.includes('.') && !typed.includes(' ')) return `https://${typed}`;
+		return `https://www.google.com/search?q=${encodeURIComponent(typed)}`;
+	}
+
 	function onAddressKeydown(event: KeyboardEvent): void {
 		if (event.key === 'Enter') {
 			const typed = address.trim();
-			if (typed) onNavigate?.(typed.includes('://') ? typed : `https://${typed}`);
+			if (typed) onNavigate?.(toUrl(typed));
 		} else if (event.key === 'Escape') {
 			address = location;
 		}

--- a/src/lib/i18n/ar.ts
+++ b/src/lib/i18n/ar.ts
@@ -328,6 +328,7 @@ export const ar: Record<MessageKey, string> = {
 	'assistant.dismiss': 'إخفاء',
 
 	'header.url': 'أنت هنا',
+	'header.reload': 'إعادة تحميل الصفحة',
 
 	'log.column.time': 'الوقت',
 	'log.column.level': 'المستوى',

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -345,6 +345,7 @@ export const de: Record<MessageKey, string> = {
 	'assistant.dismiss': 'Ausblenden',
 
 	'header.url': 'Du bist hier',
+	'header.reload': 'Seite neu laden',
 
 	'log.column.time': 'Zeit',
 	'log.column.level': 'Stufe',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -346,6 +346,7 @@ export const en = {
 	'assistant.dismiss': 'Dismiss',
 
 	'header.url': 'You are here',
+	'header.reload': 'Reload page',
 
 	'log.column.time': 'Time',
 	'log.column.level': 'Level',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -342,6 +342,7 @@ export const es: Record<MessageKey, string> = {
 	'assistant.dismiss': 'Ocultar',
 
 	'header.url': 'Estás aquí',
+	'header.reload': 'Recargar la página',
 
 	'log.column.time': 'Hora',
 	'log.column.level': 'Nivel',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -344,6 +344,7 @@ export const fr: Record<MessageKey, string> = {
 	'assistant.dismiss': 'Masquer',
 
 	'header.url': 'Tu es ici',
+	'header.reload': 'Recharger la page',
 
 	'log.column.time': 'Heure',
 	'log.column.level': 'Niveau',

--- a/src/lib/i18n/hi.ts
+++ b/src/lib/i18n/hi.ts
@@ -335,6 +335,7 @@ export const hi: Record<MessageKey, string> = {
 	'assistant.dismiss': 'हटाएँ',
 
 	'header.url': 'आप यहाँ हैं',
+	'header.reload': 'पेज फिर से लोड करें',
 
 	'log.column.time': 'समय',
 	'log.column.level': 'स्तर',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -342,6 +342,7 @@ export const it: Record<MessageKey, string> = {
 	'assistant.dismiss': 'Nascondi',
 
 	'header.url': 'Sei qui',
+	'header.reload': 'Ricarica la pagina',
 
 	'log.column.time': 'Ora',
 	'log.column.level': 'Livello',

--- a/src/lib/i18n/ja.ts
+++ b/src/lib/i18n/ja.ts
@@ -333,6 +333,7 @@ export const ja: Record<MessageKey, string> = {
 	'assistant.dismiss': '閉じる',
 
 	'header.url': '現在の場所',
+	'header.reload': 'ページを再読み込み',
 
 	'log.column.time': '時刻',
 	'log.column.level': 'レベル',

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -341,6 +341,7 @@ export const pt: Record<MessageKey, string> = {
 	'assistant.dismiss': 'Esconder',
 
 	'header.url': 'Estás aqui',
+	'header.reload': 'Recarregar a página',
 
 	'log.column.time': 'Hora',
 	'log.column.level': 'Nível',

--- a/src/lib/i18n/ru.ts
+++ b/src/lib/i18n/ru.ts
@@ -337,6 +337,7 @@ export const ru: Record<MessageKey, string> = {
 	'assistant.dismiss': 'Скрыть',
 
 	'header.url': 'Вы здесь',
+	'header.reload': 'Перезагрузить страницу',
 
 	'log.column.time': 'Время',
 	'log.column.level': 'Уровень',

--- a/src/lib/i18n/zh.ts
+++ b/src/lib/i18n/zh.ts
@@ -320,6 +320,7 @@ export const zh: Record<MessageKey, string> = {
 	'assistant.dismiss': '关闭',
 
 	'header.url': '你在这里',
+	'header.reload': '重新加载页面',
 
 	'log.column.time': '时间',
 	'log.column.level': '级别',

--- a/src/lib/stores/site-login.svelte.ts
+++ b/src/lib/stores/site-login.svelte.ts
@@ -13,6 +13,8 @@ export class SiteLoginStore {
 				if (event.payload.url) {
 					this.url = { ...this.url, [event.payload.platform]: event.payload.url };
 				}
+			} else if (event.event === 'siteUrl') {
+				this.url = { ...this.url, [event.payload.platform]: event.payload.url };
 			}
 		});
 	}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -555,6 +555,9 @@
 					{location}
 					{settingsStore}
 					onMenuOpenChange={(open: boolean) => (headerMenuOpen = open)}
+					onReload={railPlatform
+						? () => void bridge.call('site.reload', { platform: railPlatform }).catch(() => {})
+						: undefined}
 					onToggleAssistant={assistantReady ? () => (assistantOpen = !assistantOpen) : undefined}
 					assistantOpen={assistantVisible}
 					onOpenActions={railPlatform && !panelVisible

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -558,6 +558,10 @@
 					onReload={railPlatform
 						? () => void bridge.call('site.reload', { platform: railPlatform }).catch(() => {})
 						: undefined}
+					onNavigate={railPlatform
+						? (url: string) =>
+								void bridge.call('site.open', { platform: railPlatform, url }).catch(() => {})
+						: undefined}
 					onToggleAssistant={assistantReady ? () => (assistantOpen = !assistantOpen) : undefined}
 					assistantOpen={assistantVisible}
 					onOpenActions={railPlatform && !panelVisible

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -558,10 +558,6 @@
 					onReload={railPlatform
 						? () => void bridge.call('site.reload', { platform: railPlatform }).catch(() => {})
 						: undefined}
-					onNavigate={railPlatform
-						? (url: string) =>
-								void bridge.call('site.open', { platform: railPlatform, url }).catch(() => {})
-						: undefined}
 					onToggleAssistant={assistantReady ? () => (assistantOpen = !assistantOpen) : undefined}
 					assistantOpen={assistantVisible}
 					onOpenActions={railPlatform && !panelVisible


### PR DESCRIPTION
The fix for #64, plus the header work that grew out of testing it. Release notes in `release-notes/v3.5.1.md`.

**Reposts fix (#64)**
- X moved reposts off the profile timeline into a Reposts tab of their own; deleting reposts still opened the profile and reported nothing to remove. App and extension now open `x.com/<user>/reposts`, and the standalone script's header names that page too.

**Header**
- New: a reload button beside the assistant toggle while X or YouTube is up, triggering the same `site.reload` a finished run already does.
- Fix: the address shown in the header follows every document navigation of the site webview (`on_navigation` → `siteUrl` push event). It used to freeze on the last platform page once the user followed a link off the platform's hosts, where the injected reporter goes quiet. The address stays display-only.

**Release**
- Versions: app 3.5.1, extension 1.0.1.

Verified locally against a live X account: the webview lands on the Reposts tab and deletes there, and the shown address follows off-platform navigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)